### PR TITLE
Add wl-copy as a clipboard utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This script generates a prompt containing the file tree and concatenated file co
 
 ## Notes
 
-- The script checks for the presence of clipboard commands (`pbcopy`, `xclip`, `xsel`, `clip`) and uses the first one found to copy the prompt to the clipboard. If none are found, an error is displayed.
+- The script checks for the presence of clipboard commands (`pbcopy`, `xclip`, `xsel`, `clip`, `wl-copy`) and uses the first one found to copy the prompt to the clipboard. If none are found, an error is displayed.
 - The script reads `.gitignore` and `.preludeignore` files to exclude specified patterns from the file tree.
 
 ## Dependencies

--- a/prelude
+++ b/prelude
@@ -65,8 +65,10 @@ command_exists() {
 # Function to copy to clipboard
 copy_to_clipboard() {
     local prompt="$1"
-    if command_exists pbcopy; then
+    if command_exists pbcopy; then	
         echo -e "$prompt" | pbcopy
+    elif command_exists wl-copy; then
+	echo -e "$prompt" | wl-copy
     elif command_exists xclip; then
         echo -e "$prompt" | xclip -selection clipboard
     elif command_exists xsel; then


### PR DESCRIPTION
Hello !

On  Wayland, the most commonly used clipboard utility must be [wl-clipboard](https://man.archlinux.org/man/wl-clipboard.1.en)
This PR simply adds support to the wl-copy utility if it exists to copy the prompt to the clipboard.

It works just like pbcopy.