### PR TITLE
Update the way $all_entries is retrieved and presented

### DIFF
--- a/prelude
+++ b/prelude
@@ -285,7 +285,7 @@ if $git_only; then
 else
     for p in "${paths[@]}"; do
         if [ -z "$all_entries" ]; then
-            all_entries="$(find "$p" -print)"
+            all_entries="$(find "$p" -printf "%P\n")"
         else
             all_entries="$all_entries
 $(find "$p" -print)"


### PR DESCRIPTION
The final output of the command presents all the files that has been included in the context prepended by a ".", for instance, calling `prelude` from it's own repo gave this:

```
darkturo@Billy:~/src/3pp/prelude$ ./prelude -X "./.git*"
-------
PRELUDE
-------
Got prompt with file tree and concatenated file contents.
Files and directories in this file tree are included in the prompt, except for binary files.

.
./.
././LICENSE
././prelude
././README.md
././test_prelude.bats
```

It's not a big deal of an improvement, but removing the redundant "././"  started to itch quickly on me, so I had to update the script to give a nicer, less ocd-triggered look.

Now with the change this is the output you'd get:
```
darkturo@Billy:~/src/contrib/prelude$ ./prelude -X ".git*"
-------
PRELUDE
-------
Got prompt with file tree and concatenated file contents.
Files and directories in this file tree are included in the prompt, except for binary files.

.
./LICENSE
./README.md
./test_prelude.bats

The prompt has been copied to the clipboard.
```

